### PR TITLE
Use babel-eslint as parser

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": ["standard"],
+  "parser": "babel-eslint",
   "rules": {
     "valid-jsdoc": [
       2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-frost-standard",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Standard ESLint rules for Frost projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mocha": "^2.4.2"
   },
   "dependencies": {
+    "babel-eslint": "^4.1.6",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-standard": "^1.3.1"
   }


### PR DESCRIPTION
This tells ESLint to use `babel-eslint` as its parser which allows you to use things like ES7 decorators in your code without the linter complaining it is invalid JavaScript.