### PR TITLE
Updating major versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "babel-eslint": "^5.0.0",
     "eslint-config-standard": "^5.1.0",
+    "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "eslint"
   ],
   "author": "Adam Meadows (https://github.com/job13er)",
+  "contributors": [
+    "Steven Glanzer (https://github.com/sglanzer)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ciena-frost/frost-standard/issues"
@@ -24,13 +27,13 @@
   "homepage": "https://github.com/ciena-frost/frost-standard#readme",
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^1.10.3",
+    "eslint": "^2.1.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.2"
   },
   "dependencies": {
-    "babel-eslint": "^4.1.7",
-    "eslint-config-standard": "^4.4.0",
+    "babel-eslint": "^5.0.0",
+    "eslint-config-standard": "^5.1.0",
     "eslint-plugin-standard": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "author": "Adam Meadows (https://github.com/job13er)",
   "contributors": [
+    "Matt Dahl (https://github.com/sandersky)",
     "Steven Glanzer (https://github.com/sglanzer)"
   ],
   "license": "MIT",


### PR DESCRIPTION
This is a #major# change to move up the next versions of eslint and associated projects