### PR TITLE
eslint@3.x and mocha rules

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,17 +1,18 @@
 {
   "extends": ["standard"],
   "parser": "babel-eslint",
+  "plugins": ["mocha"],
   "rules": {
     "camelcase": 2,
     "max-len": [2, 120, 4, {
       "ignoreComments": true,
       "ignoreUrls": true
     }],
-    "handle-done-callback": 2,
-    "no-exclusive-tests": 2,
-    "no-global-tests": 2,
-    "no-pending-tests": 2,
-    "no-skipped-tests": 1,
+    "mocha/handle-done-callback": 2,
+    "mocha/no-exclusive-tests": 2,
+    "mocha/no-global-tests": 2,
+    "mocha/no-pending-tests": 2,
+    "mocha/no-skipped-tests": 1,
     "valid-jsdoc": [
       2,
       {

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -2,6 +2,16 @@
   "extends": ["standard"],
   "parser": "babel-eslint",
   "rules": {
+    "camelcase": 2,
+    "max-len": [2, 120, 4, {
+      "ignoreComments": true,
+      "ignoreUrls": true
+    }],
+    "handle-done-callback": 2,
+    "no-exclusive-tests": 2,
+    "no-global-tests": 2,
+    "no-pending-tests": 2,
+    "no-skipped-tests": 1,
     "valid-jsdoc": [
       2,
       {
@@ -26,11 +36,6 @@
         },
         "requireReturn": false
       }
-    ],
-    "camelcase": 2,
-    "max-len": [2, 120, 4, {
-      "ignoreComments": true,
-      "ignoreUrls": true
-    }]
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,14 +28,15 @@
   "homepage": "https://github.com/ciena-frost/frost-standard#readme",
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^2.8.0",
+    "eslint": "^3.0.1",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.2"
   },
   "dependencies": {
-    "babel-eslint": "^6.0.0",
-    "eslint-config-standard": "^5.2.0",
-    "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.1"
+    "babel-eslint": "^6.1.2",
+    "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-mocha": "^4.0.0",
+    "eslint-plugin-promise": "^2.0.0",
+    "eslint-plugin-standard": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "babel-eslint": "^6.1.2",
     "eslint-config-standard": "^5.3.5",
-    "eslint-plugin-mocha": "^4.0.0",
+    "eslint-plugin-mocha": "job13er/eslint-plugin-mocha#add-ember-mocha-support",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0"
   }


### PR DESCRIPTION
This is a #major# change, b/c we switch to new major version of `eslint`

# CHANGELOG
## Breaking changes
 * **Switched** to `eslint@3.x`

## New Rules

 * **Added** rule to error on a `describe.only` or `describeComponent.only` in tests
 * **Added** rule to warn on a `describe.skip` or `it.skip` (with `--fix` option 😄 )
 * **Added** rule to error on an `it('pending test')` with no test
 * **Added** rule to error on a global `it()`(not within a test suite)
 * **Added** rule to error if the `done` callback isn't called when it's defined.