### PR TITLE
Fix mocha rules to not use job13er's fork

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -10,10 +10,22 @@
       "ignoreUrls": true
     }],
     "mocha/handle-done-callback": 2,
-    "mocha/no-exclusive-tests": 2,
+    "mocha/no-exclusive-tests": [2, {
+      "additionalTestFunctions": [
+        "describeComponent",
+        "describeModel",
+        "describeModule"
+      ]
+    }],
     "mocha/no-global-tests": 2,
     "mocha/no-pending-tests": 2,
-    "mocha/no-skipped-tests": 1,
+    "mocha/no-skipped-tests": [1, {
+      "additionalTestFunctions": [
+        "describeComponent",
+        "describeModel",
+        "describeModule"
+      ]
+    }],
     "valid-jsdoc": [
       2,
       {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "babel-eslint": "^6.1.2",
     "eslint-config-standard": "^5.3.5",
-    "eslint-plugin-mocha": "job13er/eslint-plugin-mocha#add-ember-mocha-support",
+    "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0"
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
 * **Updated** `eslint-plugin-mocha` to allow us to stop using the fork from `job13er`

