### PR TITLE
Add a new rule `no-unused-expressions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Make sure you don't include empty `it()` calls. More details available [here](ht
 
 #### `mocha/no-skipped-tests`
 Emit a warning when you use `it.skip()` or `describe.skip()`. Sometimes it's necessary, but it's nice to easily see them all listed out in one place, and they should be temporary whenever they are checked in. More details available [here](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-skipped-tests.md).
+
+### `no-unused-expressions`
+Stop developers from using property assertions like `expect(foo).to.be.true`. Mainly because of [this issue](https://github.com/chaijs/chai/issues/726).
+More details available [here](http://eslint.org/docs/rules/no-unused-expressions).

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -26,6 +26,7 @@
         "describeModule"
       ]
     }],
+    "no-unused-expressions": 2,
     "valid-jsdoc": [
       2,
       {

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -26,7 +26,9 @@
         "describeModule"
       ]
     }],
-    "no-unused-expressions": 2,
+    "no-unused-expressions": [2, {
+      "allowTernary": true
+    }],
     "valid-jsdoc": [
       2,
       {

--- a/tests/index-spec.js
+++ b/tests/index-spec.js
@@ -12,15 +12,31 @@ describe('config', () => {
     })
 
     const code = 'var foo = 1\nvar bar = function () {}\nbar(foo)\n'
-    expect(cli.executeOnText(code).errorCount).to.be.equal(0)
+    expect(cli.executeOnText(code).errorCount).to.equal(0)
   })
 
-  it('extends standard', () => {
-    expect(config.extends[0]).to.be.equal('standard')
+  it('should extend standard', () => {
+    expect(config.extends[0]).to.equal('standard')
   })
 
-  it('includes valid-jsdoc', () => {
-    expect(config.rules['valid-jsdoc']).not.to.be.null
+  it('should include camelcase', () => {
+    expect(config.rules.camelcase).not.to.equal(undefined)
+  })
+
+  it('should include complexity', () => {
+    expect(config.rules.complexity).not.to.equal(undefined)
+  })
+
+  it('should include max-len', () => {
+    expect(config.rules['max-len']).not.to.equal(undefined)
+  })
+
+  it('should include no-unused-expressions', () => {
+    expect(config.rules['no-unused-expressions']).not.to.equal(undefined)
+  })
+
+  it('should include valid-jsdoc', () => {
+    expect(config.rules['valid-jsdoc']).not.to.equal(undefined)
   })
 })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [X] #major# - incompatible API change

# CHANGELOG
* **Added** an additional rule: `no-unused-expressions` which will disallow `expect(foo).to.be.true` style assertions. See [this issue](https://github.com/chaijs/chai/issues/726) for more info. 
