### PR TITLE
Add eslint-plugin-ember-standard and eslint-plugin-ocd

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,10 +1,22 @@
 {
   "extends": ["standard"],
   "parser": "babel-eslint",
-  "plugins": ["mocha"],
+  "plugins": [
+    "ember-standard",
+    "mocha",
+    "ocd"
+  ],
   "rules": {
     "camelcase": 2,
     "complexity": [2, 5],
+    "ember-standard/computed-property-readonly": [1, "always"],
+    "ember-standard/destructure": [1, "always"],
+    "ember-standard/import": [1, "always"],
+    "ember-standard/logger": [1, "always"],
+    "ember-standard/no-set-in-computed-property": 1,
+    "ember-standard/no-settimeout": 1,
+    "ember-standard/prop-types": 1,
+    "ember-standard/single-destructure": 1,
     "max-len": [2, 120, 4, {
       "ignoreComments": true,
       "ignoreUrls": true
@@ -29,6 +41,7 @@
     "no-unused-expressions": [2, {
       "allowTernary": true
     }],
+    "ocd/sort-imports": 1,
     "valid-jsdoc": [
       2,
       {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "dependencies": {
     "babel-eslint": "^6.1.2",
     "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-ember-standard": "0.0.18",
     "eslint-plugin-mocha": "^4.7.0",
+    "eslint-plugin-ocd": "0.0.1",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0"
   }

--- a/tests/index-spec.js
+++ b/tests/index-spec.js
@@ -19,6 +19,80 @@ describe('config', () => {
     expect(config.extends[0]).to.equal('standard')
   })
 
+  describe('ember-standard plugin', function () {
+    it('is included', function () {
+      expect(config.plugins).to.include('ember-standard')
+    })
+
+    it('includes computed-property-readonly rule', function () {
+      expect(config.rules['ember-standard/computed-property-readonly']).not.to.equal(undefined)
+    })
+
+    it('includes destructure rule', function () {
+      expect(config.rules['ember-standard/destructure']).not.to.equal(undefined)
+    })
+
+    it('includes import rule', function () {
+      expect(config.rules['ember-standard/import']).not.to.equal(undefined)
+    })
+
+    it('includes logger rule', function () {
+      expect(config.rules['ember-standard/logger']).not.to.equal(undefined)
+    })
+
+    it('includes no-set-in-computed-property rule', function () {
+      expect(config.rules['ember-standard/no-set-in-computed-property']).not.to.equal(undefined)
+    })
+
+    it('includes no-settimeout rule', function () {
+      expect(config.rules['ember-standard/no-settimeout']).not.to.equal(undefined)
+    })
+
+    it('includes prop-types rule', function () {
+      expect(config.rules['ember-standard/prop-types']).not.to.equal(undefined)
+    })
+
+    it('includes single-destructure rule', function () {
+      expect(config.rules['ember-standard/single-destructure']).not.to.equal(undefined)
+    })
+  })
+
+  describe('mocha plugin', function () {
+    it('is included', function () {
+      expect(config.plugins).to.include('mocha')
+    })
+
+    it('includes handle-done-callback rule', function () {
+      expect(config.rules['mocha/handle-done-callback']).not.to.equal(undefined)
+    })
+
+    it('includes no-exclusive-tests rule', function () {
+      expect(config.rules['mocha/no-exclusive-tests']).not.to.equal(undefined)
+    })
+
+    it('includes no-global-tests rule', function () {
+      expect(config.rules['mocha/no-global-tests']).not.to.equal(undefined)
+    })
+
+    it('includes no-pending-tests rule', function () {
+      expect(config.rules['mocha/no-pending-tests']).not.to.equal(undefined)
+    })
+
+    it('includes no-skipped-tests rule', function () {
+      expect(config.rules['mocha/no-skipped-tests']).not.to.equal(undefined)
+    })
+  })
+
+  describe('ocd plugin', function () {
+    it('is included', function () {
+      expect(config.plugins).to.include('ocd')
+    })
+
+    it('includes sort-imports rule', function () {
+      expect(config.rules['ocd/sort-imports']).not.to.equal(undefined)
+    })
+  })
+
   it('should include camelcase', () => {
     expect(config.rules.camelcase).not.to.equal(undefined)
   })
@@ -39,4 +113,3 @@ describe('config', () => {
     expect(config.rules['valid-jsdoc']).not.to.equal(undefined)
   })
 })
-


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** plugins [ember-standard](https://github.com/ciena-blueplanet/eslint-plugin-ember-standard) and [ocd](https://github.com/ciena-blueplanet/eslint-plugin-ocd) and configured their rules as warnings (will switch to errors in the next major release).
