### PR TITLE
Fix ocd/sort-imports rule to separate internal and external modules

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -42,7 +42,16 @@
       "allowTernary": true
     }],
     "ocd/sort-import-declaration-specifiers": 1,
-    "ocd/sort-import-declarations": 1,
+    "ocd/sort-import-declarations": [
+      1,
+      {
+        "localPrefixes": [
+          "../",
+          "./",
+          "dummy/"
+        ]
+      }
+    ],
     "ocd/sort-variable-declarator-properties": 1,
     "valid-jsdoc": [
       2,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-standard": "^5.3.5",
     "eslint-plugin-ember-standard": "0.0.18",
     "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-ocd": "0.0.4",
+    "eslint-plugin-ocd": "0.0.5",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0"
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `ocd/sort-imports` rule to separate internal and external modules.
