### PR TITLE
Warn on object curly spacing

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -41,6 +41,7 @@
     "no-unused-expressions": [2, {
       "allowTernary": true
     }],
+    "object-curly-spacing": [1, "never"],
     "ocd/sort-import-declaration-specifiers": 1,
     "ocd/sort-import-declarations": [
       1,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-standard": "^5.3.5",
     "eslint-plugin-ember-standard": "0.0.18",
     "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-ocd": "0.0.5",
+    "eslint-plugin-ocd": "0.0.6",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0"
   }

--- a/tests/index-spec.js
+++ b/tests/index-spec.js
@@ -117,6 +117,10 @@ describe('config', () => {
     expect(config.rules['no-unused-expressions']).not.to.equal(undefined)
   })
 
+  it('should include object-curly-spacing', () => {
+    expect(config.rules['object-curly-spacing']).not.to.equal(undefined)
+  })
+
   it('should include valid-jsdoc', () => {
     expect(config.rules['valid-jsdoc']).not.to.equal(undefined)
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** warning to when using [object curly spacing](http://eslint.org/docs/rules/object-curly-spacing).
