### PR TITLE
Upgrade ember standard plugin to 0.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "babel-eslint": "^6.1.2",
     "eslint-config-standard": "^5.3.5",
-    "eslint-plugin-ember-standard": "0.0.20",
+    "eslint-plugin-ember-standard": "0.0.22",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-ocd": "0.0.6",
     "eslint-plugin-promise": "^2.0.0",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** to eslint-plugin-ember-standard 0.0.22
