### PR TITLE
turn off no-template-curly-in-string errors on bunsen references

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = {
     'mocha/no-pending-tests': 'error',
     'mocha/no-skipped-tests': 'warn',
     'mocha/valid-test-description': 'error',
+    'no-template-curly-in-string': 'off',
     'no-unused-expressions': ['error', {
       allowTernary: true
     }],


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* turn off `no-template-curly-in-string`
 * breaks bunsen references such as `'nC.id': '${./nEname}',`
