### PR TITLE
Update eslint-plugin-ember-standard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "eslint-config-standard": "10.2.1",
-    "eslint-plugin-ember-standard": "0.0.23",
+    "eslint-plugin-ember-standard": "0.1.0",
     "eslint-plugin-import": "2.6.0",
     "eslint-plugin-mocha": "4.11.0",
     "eslint-plugin-node": "4.2.2",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** eslint-plugin-ember-standard to new version which add support for `ember-decorators` to the `computed-readonly` rule